### PR TITLE
Add error-handling for `gl.create()`

### DIFF
--- a/gologin/gologin.py
+++ b/gologin/gologin.py
@@ -21,6 +21,14 @@ PROFILES_URL = 'https://gprofiles-new.gologin.com/'
 GET_TIMEZONE_URL = 'https://geo.myip.link'
 FILES_GATEWAY = ' https://files-gateway.gologin.com'
 
+class ProtocolException(Exception):
+    def __init__(self, data:dict):
+        self._json =data
+        super().__init__(data.__repr__())
+    @property
+    def json(self) -> dict:
+        return self._json
+
 class GoLogin(object):
     def __init__(self, options):
         self.access_token = options.get('token')
@@ -653,6 +661,8 @@ class GoLogin(object):
 
         response = json.loads(requests.post(
             API_URL + '/browser', headers=self.headers(), json=profile).content.decode('utf-8'))
+        if response['statusCode'] != 200:
+            raise ProtocolException(response)
         return response.get('id')
 
     def delete(self, profile_id=None):

--- a/gologin/gologin.py
+++ b/gologin/gologin.py
@@ -661,7 +661,6 @@ class GoLogin(object):
 
         response = json.loads(requests.post(
             API_URL + '/browser', headers=self.headers(), json=profile).content.decode('utf-8'))
-        status = 
         if not (response.get('statusCode') is None):
             raise ProtocolException(response)
         return response.get('id')

--- a/gologin/gologin.py
+++ b/gologin/gologin.py
@@ -661,7 +661,8 @@ class GoLogin(object):
 
         response = json.loads(requests.post(
             API_URL + '/browser', headers=self.headers(), json=profile).content.decode('utf-8'))
-        if response['statusCode'] != 200:
+        status = 
+        if not (response.get('statusCode') is None):
             raise ProtocolException(response)
         return response.get('id')
 


### PR DESCRIPTION
at least for
```json
{"error": "Forbidden", "message": "You've reached max profiles number. To create more update your plan", "statusCode": 403}
```
quite crucial.
Without that, raises a missleading:
```
Traceback (most recent call last):
  File "D:\System\Lib\Python\Python310\lib\site-packages\aiohttp\web_protocol.py", line 452, in _handle_request
    resp = await request_handler(request)
  File "D:\System\Lib\Python\Python310\lib\site-packages\aiohttp\web_app.py", line 543, in _handle
    resp = await handler(request)
  File "D:\Projects\PyCharm\hermes\my_server.py", line 10, in get_category
    with gologin_options() as options:
  File "D:\Projects\PyCharm\hermes\my_script.py", line 336, in __enter__
    debugger_address = self.gl.start()
  File "D:\System\Lib\Python\Python310\lib\site-packages\gologin\gologin.py", line 156, in start
    data = requests.get('http://'+url+'/json').content
  File "D:\System\Lib\Python\Python310\lib\site-packages\gologin\gologin.py", line 506, in createStartup
    gologin = self.convertPreferences(profile)
AttributeError: 'GoLogin' object has no attribute 'profile_path'
```

Note: This should (technically) be handled for any api call, not just `create`