### PR TITLE
Fix json payload paramter for make_request calls

### DIFF
--- a/gologin/gologin.py
+++ b/gologin/gologin.py
@@ -1078,7 +1078,7 @@ class GoLogin(object):
                 'User-Agent': 'gologin-api',
                 'Content-Type': 'application/json',
             },
-            json={
+            json_data={
                 "countryCode": countryCode,
                 "isDc": isDc,
                 "isMobile": isMobile,
@@ -1102,7 +1102,7 @@ class GoLogin(object):
                 'User-Agent': 'gologin-api',
                 'Content-Type': 'application/json',
             },
-            json=cookies
+            json_data=cookies
         )
 
         return response.status_code


### PR DESCRIPTION
Changed parameter name from json to json_data in startRemote method
Fixed similar parameter naming issues in other methods calling make_request()



- The fix resolves the error: TypeError: make_request() got an unexpected keyword argument 'json'